### PR TITLE
stop 'possible EventEmitter memory leak detected' from printing in th…

### DIFF
--- a/lib/TestRunner.js
+++ b/lib/TestRunner.js
@@ -113,6 +113,10 @@ exports.runTests = function (callback) {
       'details': []
     };
 
+  //each test will add a new event listener.
+  //Increase the MaxListeners value on the eventemitter
+  eventEmitter.setMaxListeners(tests.length);
+
   // Set the isRunning flag
   isRunning = true;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-health",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A wrapper to add a health endpoint to your cloud application based on nodeapp.",
   "main": "./lib/TestRunner.js",
   "scripts": {
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "grunt": "~0.4.5",
-    "grunt-lintspaces": "^0.5.1",
+    "grunt-lintspaces": "^0.8.0",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-column-lint": "~0.2.0",
     "mocha": "~1.20.1",

--- a/test/TestRunner.js
+++ b/test/TestRunner.js
@@ -1,4 +1,5 @@
 var assert = require('assert')
+  , TestEvents = require('../lib/TestEvents')
   , TestRunner = require('../lib/TestRunner');
 
 
@@ -55,6 +56,10 @@ describe('TestRunner', function() {
   });
 
   describe('Test init will add test to an exports object', function() {
+    beforeEach(function(){
+      TestEvents.removeAllListeners();
+    });
+
     it('Should run tests', function(done) {
       var fake_nodeapp = {}
       TestRunner.init(fake_nodeapp);
@@ -204,6 +209,20 @@ describe('TestRunner', function() {
 
       TestRunner.runTests(cb1);
       TestRunner.runTests(cb2);
+    });
+
+    it('should not print EventEmitter memory leak warning', function(done) {
+      var NUMER_OF_TESTS = 11;
+      for(var i = 0; i< NUMER_OF_TESTS; i++) {
+        TestRunner.addTest('Run the fake test #' + i, passingTest);
+      }
+
+      function cb(err) {
+        assert(!err);
+        done();
+      }
+
+      TestRunner.runTests(cb);
     });
   });
 });


### PR DESCRIPTION
…e logs

If there are more than 10 tests added, there will be a 'possible EventEmitter memory leak detected' message and stacktrace printed in the logs. It's not a big deal but kind of annoying.

This PR will prevent that message from printing.

To verify:

Run the test and there should be no such messages printed anymore.
